### PR TITLE
Disabling certificate fingerprint parsing

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -717,6 +717,12 @@ int getTLScertificate(struct ndpi_detection_module_struct *ndpi_struct,
 /* See https://blog.catchpoint.com/2017/05/12/dissecting-tls-using-wireshark/ */
 int getSSCertificateFingerprint(struct ndpi_detection_module_struct *ndpi_struct,
 				struct ndpi_flow_struct *flow) {
+
+
+  /* Disabling getting the certificate fingerprint */
+  printf("[TLS] Skip getSSCertificateFingerprint() for now\n");
+  return (1); /* Refer #8002 for more details */
+
   struct ndpi_packet_struct *packet = &flow->packet;
   u_int8_t multiple_messages;
 
@@ -757,14 +763,15 @@ int getSSCertificateFingerprint(struct ndpi_detection_module_struct *ndpi_struct
     printf("\n");
 #endif
     
-    SHA1Update(flow->l4.tcp.tls_srv_cert_fingerprint_ctx,
+
+    NDPI_SHA1Update(flow->l4.tcp.tls_srv_cert_fingerprint_ctx,
 	       &packet->payload[flow->l4.tcp.tls_record_offset],
 	       avail);
       
     flow->l4.tcp.tls_fingerprint_len -= avail;
       
     if(flow->l4.tcp.tls_fingerprint_len == 0) {
-      SHA1Final(flow->l4.tcp.tls_sha1_certificate_fingerprint, flow->l4.tcp.tls_srv_cert_fingerprint_ctx);
+      NDPI_SHA1Final(flow->l4.tcp.tls_sha1_certificate_fingerprint, flow->l4.tcp.tls_srv_cert_fingerprint_ctx);
 
 #ifdef DEBUG_TLS
       {

--- a/src/lib/third_party/include/ndpi_sha1.h
+++ b/src/lib/third_party/include/ndpi_sha1.h
@@ -13,5 +13,5 @@ typedef struct {
 
 void SHA1Transform(u_int32_t state[5], const unsigned char buffer[64]);
 void SHA1Init(SHA1_CTX* context);
-void SHA1Update(SHA1_CTX* context, const unsigned char* data, u_int32_t len);
-void SHA1Final(unsigned char digest[20], SHA1_CTX* context);
+void NDPI_SHA1Update(SHA1_CTX* context, const unsigned char* data, u_int32_t len);
+void NDPI_SHA1Final(unsigned char digest[20], SHA1_CTX* context);

--- a/src/lib/third_party/src/ndpi_sha1.c
+++ b/src/lib/third_party/src/ndpi_sha1.c
@@ -178,7 +178,7 @@ void SHA1Init(SHA1_CTX* context)
 
 /* Run your data through this. */
 
-void SHA1Update(SHA1_CTX* context, const unsigned char* data, u_int32_t len)
+void NDPI_SHA1Update(SHA1_CTX* context, const unsigned char* data, u_int32_t len)
 {
 u_int32_t i;
 u_int32_t j;
@@ -203,7 +203,7 @@ u_int32_t j;
 
 /* Add padding and return the message digest. */
 
-void SHA1Final(unsigned char digest[20], SHA1_CTX* context)
+void NDPI_SHA1Final(unsigned char digest[20], SHA1_CTX* context)
 {
 unsigned i;
 unsigned char finalcount[8];
@@ -232,12 +232,12 @@ unsigned char c;
     }
 #endif
     c = 0200;
-    SHA1Update(context, &c, 1);
+    NDPI_SHA1Update(context, &c, 1);
     while ((context->count[0] & 504) != 448) {
 	c = 0000;
-        SHA1Update(context, &c, 1);
+        NDPI_SHA1Update(context, &c, 1);
     }
-    SHA1Update(context, finalcount, 8);  /* Should cause a SHA1Transform() */
+    NDPI_SHA1Update(context, finalcount, 8);  /* Should cause a SHA1Transform() */
     for (i = 0; i < 20; i++) {
         digest[i] = (unsigned char)
          ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
@@ -263,8 +263,8 @@ main(int argc, char **argv)
 
     SHA1Init(&ctx);
     for(i=0;i<1000;i++)
-        SHA1Update(&ctx, buf, BUFSIZE);
-    SHA1Final(hash, &ctx);
+        NDPI_SHA1Update(&ctx, buf, BUFSIZE);
+    NDPI_SHA1Final(hash, &ctx);
 
     printf("SHA1=");
     for(i=0;i<20;i++)


### PR DESCRIPTION
Re: #8002
To avoid the invalid write, disabling the unused fingerprint parsing
Renaming few functions prefixing with NDPI